### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.3](https://github.com/BobG1983/rantz_random/compare/v0.4.2...v0.4.3) - 2024-06-19
+
+### Other
+- Reverting version change so that release-plz can handle it
+- Added release-plz
+- RandomContainer and RandomWeightedContainer now return Options to better handle empty tables
+- Fixed more doc comments.
+- Fixed docs
+- WeightedTable IntoIter now iters over values only. Shuffle now depends on RandomContainer, and RandomContainer was expanded.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
 
 [[package]]
 name = "rantz_random"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bevy",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rantz_random"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Robert Gardner'"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `rantz_random`: 0.4.2 -> 0.4.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.3](https://github.com/BobG1983/rantz_random/compare/v0.4.2...v0.4.3) - 2024-06-19

### Other
- Reverting version change so that release-plz can handle it
- Added release-plz
- RandomContainer and RandomWeightedContainer now return Options to better handle empty tables
- Fixed more doc comments.
- Fixed docs
- WeightedTable IntoIter now iters over values only. Shuffle now depends on RandomContainer, and RandomContainer was expanded.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).